### PR TITLE
Run owasp dependency check in travis cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 script:
 - ./gradlew test
+- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./gradlew dependencyCheckAnalyze; fi
 
 after_success:
 - ./gradlew jacocoTestReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ cache:
 
 script:
 - ./gradlew test
-- test "$TRAVIS_EVENT_TYPE" == "cron" && ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAnalyze
+- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAnalyze; fi
+
 after_success:
 - ./gradlew jacocoTestReport
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 script:
 - ./gradlew test
-- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./gradlew dependencyCheckAnalyze; fi
+- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAggregate; fi
 
 after_success:
 - ./gradlew jacocoTestReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ cache:
 
 script:
 - ./gradlew test
-- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAggregate; fi
-
+- test "$TRAVIS_EVENT_TYPE" == "cron" && ./gradlew -DdependencyCheck.failBuild=true dependencyCheckAnalyze
 after_success:
 - ./gradlew jacocoTestReport
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Only when it's triggered by cron (once a day).

Docs:
https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron

There's an alternative solution used in https://github.com/hmcts/java-logging where a cron runs on a special branch that has a special travisfile, but it needs to manualy kept up to date

