### PR TITLE
Add eventId to transformation result model

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
@@ -9,18 +9,21 @@ public class TransformationResult {
     public final List<String> errors;
     public final Map<String, Object> data;
     public final String caseTypeId;
+    public final String eventId;
 
     // region constructor
     public TransformationResult(
         List<String> warnings,
         List<String> errors,
         Map<String, Object> data,
-        String caseTypeId
+        String caseTypeId,
+        String eventId
     ) {
         this.warnings = warnings;
         this.errors = errors;
         this.data = data;
         this.caseTypeId = caseTypeId;
+        this.eventId = eventId;
     }
     // endregion
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/testutils/sampledata/SampleTransformationResult.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/testutils/sampledata/SampleTransformationResult.java
@@ -32,7 +32,8 @@ public final class SampleTransformationResult {
                 "tr_key_1", "tr_value_1",
                 "tr_key_2", "tr_value_2"
             ),
-            "some_case_type_id"
+            "some_case_type_id",
+            "some_event_id"
         );
     }
 


### PR DESCRIPTION
SSCS, for example, uses 4 different event ids when creating cases:

https://github.com/hmcts/sscs-bulk-scan/blob/master/src/main/java/uk/gov/hmcts/reform/sscs/helper/SscsDataHelper.java#L46