### PR TITLE
Change case data type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
 
-import java.util.Map;
 import java.util.function.Supplier;
 
 public class CcdClient {
@@ -11,7 +10,7 @@ public class CcdClient {
         this.s2sTokenSupplier = s2sTokenSupplier;
     }
 
-    public String createCase(Map<String, Object> data, String idamToken) {
+    public String createCase(Object data, String idamToken) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
@@ -1,13 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
 
 import java.util.List;
-import java.util.Map;
 
 public class TransformationResult {
 
     public final List<String> warnings;
     public final List<String> errors;
-    public final Map<String, Object> data;
+    public final Object data;
     public final String caseTypeId;
     public final String eventId;
 
@@ -15,7 +14,7 @@ public class TransformationResult {
     public TransformationResult(
         List<String> warnings,
         List<String> errors,
-        Map<String, Object> data,
+        Object data,
         String caseTypeId,
         String eventId
     ) {


### PR DESCRIPTION
Allow users to return an `Object` instead of `Map<String, Object>` as a transformation result.