### PR TITLE
Restructure ccd api module

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/CcdApi.java
@@ -1,8 +1,11 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api;
 
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataReq;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataResp;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
 
 @SuppressWarnings("checkstyle:LineLength")
 public interface CcdApi {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/CaseDataReq.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/CaseDataReq.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/CaseDataResp.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/CaseDataResp.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/Event.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model;
 
 public class Event {
     public final String id;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/StartEventResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/api/model/StartEventResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdApiStartEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdApiStartEventTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import feign.Feign;
+import feign.FeignException;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.CcdApi;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.testutils.JsonHelper.json;
+
+public class CcdApiStartEventTest {
+
+    private WireMockServer wireMockServer;
+    private CcdApi ccdApi;
+
+    // region setup
+    @BeforeEach
+    public void setUp() {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+
+        ccdApi = Feign.builder()
+            .decoder(new JacksonDecoder())
+            .encoder(new JacksonEncoder())
+            .target(CcdApi.class, "http://localhost:8080");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        wireMockServer.stop();
+    }
+    // endregion
+
+    @Test
+    void should_send_valid_request() {
+        // given
+        String token = "hello!";
+        stubFor(
+            get(urlEqualTo("/caseworkers/user1/jurisdictions/jur1/case-types/caseType1/event-triggers/eventId1/token"))
+                .withHeader("Authorization", equalTo("idam-token1"))
+                .withHeader("ServiceAuthorization", equalTo("s2s-token1"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody(json("{ 'token' : '" + token + "' }"))
+                ));
+
+        // when
+        StartEventResponse resp = ccdApi.startEvent(
+            "user1",
+            "idam-token1",
+            "s2s-token1",
+            "jur1",
+            "caseType1",
+            "eventId1"
+        );
+
+        // then
+        assertThat(resp.token).isEqualTo(token);
+    }
+
+    @Test
+    void should_throw_an_exception_when_request_failed() {
+        // given
+        stubFor(get(anyUrl()).willReturn(serverError()));
+
+        // when
+        Throwable exc = catchThrowable(
+            () -> ccdApi.startEvent("user1", "idam-token1", "s2s-token1", "jur1", "caseType1", "eventId1")
+        );
+
+        // then
+        assertThat(exc).isInstanceOf(FeignException.InternalServerError.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdApiSubmitEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdApiSubmitEventTest.java
@@ -9,12 +9,15 @@ import feign.jackson.JacksonEncoder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.CcdApi;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataReq;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataResp;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.Event;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -23,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.testutils.JsonHelper.json;
 
-public class CcdApiTest {
+public class CcdApiSubmitEventTest {
 
     private WireMockServer wireMockServer;
     private CcdApi ccdApi;
@@ -47,35 +50,7 @@ public class CcdApiTest {
     // endregion
 
     @Test
-    void startEvent_should_send_valid_request() {
-        // given
-        String token = "hello!";
-        stubFor(
-            get(urlEqualTo("/caseworkers/user1/jurisdictions/jur1/case-types/caseType1/event-triggers/eventId1/token"))
-                .withHeader("Authorization", equalTo("idam-token1"))
-                .withHeader("ServiceAuthorization", equalTo("s2s-token1"))
-                .willReturn(
-                    aResponse()
-                        .withStatus(200)
-                        .withBody(json("{ 'token' : '" + token + "' }"))
-                ));
-
-        // when
-        StartEventResponse resp = ccdApi.startEvent(
-            "user1",
-            "idam-token1",
-            "s2s-token1",
-            "jur1",
-            "caseType1",
-            "eventId1"
-        );
-
-        // then
-        assertThat(resp.token).isEqualTo(token);
-    }
-
-    @Test
-    void submitEvent_should_send_valid_request() {
+    void should_send_valid_request() {
         // given
         String id = "12345";
         stubFor(
@@ -119,21 +94,7 @@ public class CcdApiTest {
     }
 
     @Test
-    void startEvent_should_throw_an_exception_when_request_failed() {
-        // given
-        stubFor(get(anyUrl()).willReturn(serverError()));
-
-        // when
-        Throwable exc = catchThrowable(
-            () -> ccdApi.startEvent("user1", "idam-token1", "s2s-token1", "jur1", "caseType1", "eventId1")
-        );
-
-        // then
-        assertThat(exc).isInstanceOf(FeignException.InternalServerError.class);
-    }
-
-    @Test
-    void submitEvent_should_throw_an_exception_when_request_failed() {
+    void should_throw_an_exception_when_request_failed() {
         // given
         stubFor(post(anyUrl()).willReturn(serverError()));
 


### PR DESCRIPTION
- add sub packages
- split ccd api test into 2 classes (1 for each endpoint)