### PR TITLE
Update owasp plugin to 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '5.0.0-M3.1'
+    id 'org.owasp.dependencycheck' version '5.0.0'
 }
 
 group 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,14 @@ repositories {
     mavenCentral()
 }
 
+ext.versions = [
+    jackson: '2.9.9'
+]
+
 dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '27.1-jre'
     implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '10.2.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
     implementation group: 'org.hibernate', name: 'hibernate-validator', version: '6.0.16.Final'
     implementation group: 'org.hibernate', name: 'hibernate-validator-cdi', version: '6.0.16.Final'
     implementation group: 'org.glassfish', name: 'javax.el', version: '3.0.1-b09'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Upgrade OWASP plugin in all projects](https://tools.hmcts.net/jira/browse/BPS-677)

### Change description ###

Solving `jackson-databind` CVE-2019-12086 with version bump 2.9.8 -> 2.9.9. Former is pulled in with `feign-jackson` dependency

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
