### PR TITLE
Bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.0'
+version '0.0.1'
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
0.0.0 was release when repo was basically empty.
Currently the lib is in a state that can be used by the sample app.