### PR TITLE
Add subclasses for transformation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ to it:
 
 The handler will create a case in CCD for you and return the ID of the new case.
 
+You can check a sample implementation in
+[this](https://github.com/hmcts/bulk-scan-ccd-event-handler-sample-app) repository.
+
 ## Developing
 
 ### Prerequisites

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.1'
+version '0.0.2'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.2'
+version '0.1.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataResp;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.Event;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRequest;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
 
 import java.util.function.Supplier;
@@ -26,7 +27,7 @@ public class CcdClient {
     }
     // endregion
 
-    public String createCase(CaseCreationRequest req, TransformationResult tr) {
+    public String createCase(CaseCreationRequest req, OkTransformationResult tr) {
         log.info("Starting CCD event. CaseType: {}, EventId: {}", tr.caseTypeId, tr.eventId);
 
         StartEventResponse startEventResponse = null;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClient.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.Event;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRequest;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
 
 import java.util.function.Supplier;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.handler;
 
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.CcdClient;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.exceptions.InvalidTransformationResultTypeException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRequest;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationResult;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.validation.CaseCreationRequestValidator;
@@ -47,7 +48,7 @@ public class ExceptionRecordEventHandler {
             ErrorTransformationResult errorResult = (ErrorTransformationResult) result;
             return errors(errorResult.errors, errorResult.warnings);
         } else {
-            throw new RuntimeException();
+            throw new InvalidTransformationResultTypeException();
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
@@ -40,6 +40,7 @@ public class ExceptionRecordEventHandler {
             transformer.transform(req.exceptionRecord),
             okRes -> {
                 if (okRes.warnings.isEmpty() || req.ignoreWarnings) {
+                    // TODO: handle exceptions
                     String caseId = ccdClient.createCase(req, okRes);
                     return ok(caseId);
                 } else {
@@ -60,7 +61,7 @@ public class ExceptionRecordEventHandler {
         } else if (result instanceof ErrorTransformationResult) {
             return errorAction.apply((ErrorTransformationResult) result);
         } else {
-            throw new InvalidTransformationResultTypeException(); // TODO: add message
+            throw new InvalidTransformationResultTypeException("Invalid type: " + result.getClass().getName());
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandler.java
@@ -50,17 +50,17 @@ public class ExceptionRecordEventHandler {
         );
     }
 
-    private CaseCreationResult handleTransformationResult(
+    private <T> T handleTransformationResult(
         TransformationResult result,
-        Function<OkTransformationResult, CaseCreationResult> okAction,
-        Function<ErrorTransformationResult, CaseCreationResult> errorAction
+        Function<OkTransformationResult, T> okAction,
+        Function<ErrorTransformationResult, T> errorAction
     ) {
         if (result instanceof OkTransformationResult) {
             return okAction.apply((OkTransformationResult) result);
         } else if (result instanceof ErrorTransformationResult) {
             return errorAction.apply((ErrorTransformationResult) result);
         } else {
-            throw new InvalidTransformationResultTypeException();
+            throw new InvalidTransformationResultTypeException(); // TODO: add message
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
@@ -1,4 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.exceptions;
 
 public class InvalidTransformationResultTypeException extends RuntimeException {
+    public InvalidTransformationResultTypeException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
@@ -1,5 +1,4 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.exceptions;
 
 public class InvalidTransformationResultTypeException extends RuntimeException {
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/exceptions/InvalidTransformationResultTypeException.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.exceptions;
+
+public class InvalidTransformationResultTypeException extends RuntimeException {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/ErrorTransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/ErrorTransformationResult.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
+
+import java.util.List;
+
+public class ErrorTransformationResult extends TransformationResult {
+
+    public ErrorTransformationResult(
+        List<String> warnings,
+        List<String> errors
+    ) {
+        super(warnings, errors, null, null, null, null);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/ErrorTransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/ErrorTransformationResult.java
@@ -2,12 +2,20 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
 
 import java.util.List;
 
-public class ErrorTransformationResult extends TransformationResult {
+public class ErrorTransformationResult implements TransformationResult {
 
-    public ErrorTransformationResult(
-        List<String> warnings,
-        List<String> errors
-    ) {
-        super(warnings, errors, null, null, null, null);
+    /**
+     * Warnings that occurred during case mapping or validation.
+     */
+    public final List<String> warnings;
+
+    /**
+     * Errors that occurred during case mapping or validation.
+     */
+    public final List<String> errors;
+
+    public ErrorTransformationResult(List<String> warnings, List<String> errors) {
+        this.warnings = warnings;
+        this.errors = errors;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/OkTransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/OkTransformationResult.java
@@ -2,9 +2,33 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
 
 import java.util.List;
 
-import static java.util.Collections.emptyList;
+public class OkTransformationResult implements TransformationResult {
 
-public class OkTransformationResult extends TransformationResult {
+    /**
+     * Warnings that occurred during case mapping or validation.
+     */
+    public final List<String> warnings;
+
+    /**
+     * Object representing the case that should be created in CCD.
+     * It will be serialised to json. It can be a map or a domain object, as long as it serialises to expected json.
+     */
+    public final Object data;
+
+    /**
+     * CCD jurisdiction in which case should be created.
+     */
+    public final String jurisdiction;
+
+    /**
+     * CCD CaseTypeId that should be used when creating a case.
+     */
+    public final String caseTypeId;
+
+    /**
+     * CCD Event Id that should be used when creating a case.
+     */
+    public final String eventId;
 
     public OkTransformationResult(
         List<String> warnings,
@@ -13,6 +37,10 @@ public class OkTransformationResult extends TransformationResult {
         String caseTypeId,
         String eventId
     ) {
-        super(warnings, emptyList(), data, jurisdiction, caseTypeId, eventId);
+        this.warnings = warnings;
+        this.data = data;
+        this.jurisdiction = jurisdiction;
+        this.caseTypeId = caseTypeId;
+        this.eventId = eventId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/OkTransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/OkTransformationResult.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+public class OkTransformationResult extends TransformationResult {
+
+    public OkTransformationResult(
+        List<String> warnings,
+        Object data,
+        String jurisdiction,
+        String caseTypeId,
+        String eventId
+    ) {
+        super(warnings, emptyList(), data, jurisdiction, caseTypeId, eventId);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
 
 import java.util.List;
 
-public class TransformationResult {
+public abstract class TransformationResult {
 
     /**
      * Warnings that occurred during case mapping or validation.

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformer/model/TransformationResult.java
@@ -1,55 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model;
 
-import java.util.List;
+public interface TransformationResult {
 
-public abstract class TransformationResult {
-
-    /**
-     * Warnings that occurred during case mapping or validation.
-     */
-    public final List<String> warnings;
-
-    /**
-     * Errors that occurred during case mapping or validation.
-     */
-    public final List<String> errors;
-
-    /**
-     * Object representing the case that should be created in CCD.
-     * It will be serialised to json. It can be a map or a domain object, as long as it serialises to expected json.
-     */
-    public final Object data;
-
-    /**
-     * CCD jurisdiction in which case should be created.
-     */
-    public final String jurisdiction;
-
-    /**
-     * CCD CaseTypeId that should be used when creating a case.
-     */
-    public final String caseTypeId;
-
-    /**
-     * CCD Event Id that should be used when creating a case.
-     */
-    public final String eventId;
-
-    // region constructor
-    public TransformationResult(
-        List<String> warnings,
-        List<String> errors,
-        Object data,
-        String jurisdiction,
-        String caseTypeId,
-        String eventId
-    ) {
-        this.warnings = warnings;
-        this.errors = errors;
-        this.data = data;
-        this.jurisdiction = jurisdiction;
-        this.caseTypeId = caseTypeId;
-        this.eventId = eventId;
-    }
-    // endregion
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClientTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataReq;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataResp;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRequest;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
 
 import java.util.function.Supplier;
@@ -43,7 +44,7 @@ public class CcdClientTest {
     public void should_call_api_with_correct_params() {
         // given
         CaseCreationRequest req = caseCreationRequest();
-        TransformationResult tr = okResult();
+        OkTransformationResult tr = okResult();
         String s2s = "s2s-token";
         given(s2sTokenSupplier.get())
             .willReturn(s2s);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandlerTest.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRes
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.validation.CaseCreationRequestValidator;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.testutils.sampledata.SampleCaseCreationRequest;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.ExceptionRecordToCaseTransformer;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +43,7 @@ public class ExceptionRecordEventHandlerTest {
     public void should_handle_successful_transformation_result() {
         // given
         CaseCreationRequest req = SampleCaseCreationRequest.caseCreationRequest();
-        TransformationResult transformationResult = okResult();
+        OkTransformationResult transformationResult = okResult();
 
         given(ccdClient.createCase(any(), any())).willReturn("new-case-id");
         given(transformer.transform(req.exceptionRecord)).willReturn(transformationResult);
@@ -106,7 +106,7 @@ public class ExceptionRecordEventHandlerTest {
         // given
         CaseCreationRequest req = caseCreationRequest(true); // ignore warnings
 
-        TransformationResult transformationResult = warningResult(asList("warn1", "warn2"));
+        OkTransformationResult transformationResult = warningResult(asList("warn1", "warn2"));
 
         given(ccdClient.createCase(any(), any())).willReturn("new-case-id");
         given(transformer.transform(req.exceptionRecord)).willReturn(transformationResult);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/testutils/sampledata/SampleTransformationResult.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/testutils/sampledata/SampleTransformationResult.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.testutils.sampledata;
 
 import com.google.common.collect.ImmutableMap;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.ErrorTransformationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
 
 import java.util.List;
 
@@ -9,25 +10,13 @@ import static java.util.Collections.emptyList;
 
 public final class SampleTransformationResult {
 
-    public static TransformationResult okResult() {
-        return transformationResult(emptyList(), emptyList());
+    public static OkTransformationResult okResult() {
+        return warningResult(emptyList());
     }
 
-    public static TransformationResult warningResult(List<String> warnings) {
-        return transformationResult(warnings, emptyList());
-    }
-
-    public static TransformationResult errorResult(List<String> warnings, List<String> errors) {
-        return transformationResult(warnings, errors);
-    }
-
-    public static TransformationResult transformationResult(
-        List<String> warnings,
-        List<String> errors
-    ) {
-        return new TransformationResult(
+    public static OkTransformationResult warningResult(List<String> warnings) {
+        return new OkTransformationResult(
             warnings,
-            errors,
             ImmutableMap.of(
                 "tr_key_1", "tr_value_1",
                 "tr_key_2", "tr_value_2"
@@ -36,6 +25,10 @@ public final class SampleTransformationResult {
             "some_case_type_id",
             "some_event_id"
         );
+    }
+
+    public static ErrorTransformationResult errorResult(List<String> warnings, List<String> errors) {
+        return new ErrorTransformationResult(warnings, errors);
     }
 
     private SampleTransformationResult() {


### PR DESCRIPTION
Should simplify using the library a bit, just provide the data relevant to the 'type' of result.