### PR TITLE
 Add a flag indicating if case has been created

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.2.2'
+version '0.3.0'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.2.1'
+version '0.2.2'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/model/CaseCreationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/model/CaseCreationResult.java
@@ -13,4 +13,8 @@ public class CaseCreationResult {
         this.errors = errors;
         this.warnings = warnings;
     }
+
+    public boolean isCaseCreated() {
+        return caseId != null;
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ccd/CcdClientTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.CaseDataResp;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ccd.api.model.StartEventResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.handler.model.CaseCreationRequest;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.OkTransformationResult;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformer.model.TransformationResult;
 
 import java.util.function.Supplier;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/handler/ExceptionRecordEventHandlerTest.java
@@ -54,6 +54,7 @@ public class ExceptionRecordEventHandlerTest {
         CaseCreationResult result = handler.handle(req);
 
         // then
+        assertThat(result.isCaseCreated()).isTrue();
         assertThat(result.caseId).isEqualTo("new-case-id");
         assertThat(result.errors).isEmpty();
         assertThat(result.warnings).isEmpty();
@@ -75,6 +76,7 @@ public class ExceptionRecordEventHandlerTest {
         CaseCreationResult result = handler.handle(req);
 
         // then
+        assertThat(result.isCaseCreated()).isFalse();
         assertThat(result.caseId).isNull();
         assertThat(result.errors).containsExactly("err1", "err2");
         assertThat(result.warnings).containsExactly("warn1", "warn2");
@@ -96,6 +98,7 @@ public class ExceptionRecordEventHandlerTest {
         CaseCreationResult result = handler.handle(req);
 
         // then
+        assertThat(result.isCaseCreated()).isFalse();
         assertThat(result.caseId).isNull();
         assertThat(result.errors).isEmpty();
         assertThat(result.warnings).containsExactly("warn1", "warn2");
@@ -117,6 +120,7 @@ public class ExceptionRecordEventHandlerTest {
         CaseCreationResult result = handler.handle(req);
 
         // then
+        assertThat(result.isCaseCreated()).isTrue();
         assertThat(result.caseId).isEqualTo("new-case-id");
         assertThat(result.errors).isEmpty();
         assertThat(result.warnings).isEmpty(); // warnings removed!


### PR DESCRIPTION
### Change description ###

Add a flag indicating if case has been created. This would make the check is slightly clearer for clients of the library. Please let me know what you think.

Also, removed an unused import, as my local build failed because of it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
